### PR TITLE
Fix incompatibility with PyPortal

### DIFF
--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -50,9 +50,15 @@ import json
 import board
 from digitalio import DigitalInOut
 import displayio
-import adafruit_touchscreen
-from adafruit_cursorcontrol.cursorcontrol import Cursor
-from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
+try:
+    import adafruit_touchscreen
+except ImportError:
+    pass
+try:
+    from adafruit_cursorcontrol.cursorcontrol import Cursor
+    from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
+except ImportError:
+    pass
 import audioio
 from adafruit_display_text.label import Label
 from adafruit_button import Button

--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -96,6 +96,7 @@ class PYOA_Graphics():
         self.backlight_fade(0)
         board.DISPLAY.show(self.root_group)
         self.touchscreen = None
+        self.mouse_cursor = None
         if hasattr(board, 'TOUCH_XL'):
             self.touchscreen = adafruit_touchscreen.Touchscreen(board.TOUCH_XL, board.TOUCH_XR,
                                                                 board.TOUCH_YD, board.TOUCH_YU,
@@ -158,14 +159,16 @@ class PYOA_Graphics():
 
     def _fade_to_black(self):
         """Turn down the lights."""
-        self.mouse_cursor.is_hidden = True
+        if self.mouse_cursor:
+            self.mouse_cursor.is_hidden = True
         self.backlight_fade(0)
         # turn off background so we can render the text
         self.set_background(None, with_fade=False)
         self.set_text(None, None)
         for _ in range(len(self._button_group)):
             self._button_group.pop()
-        self.mouse_cursor.is_hidden = False
+        if self.mouse_cursor:
+            self.mouse_cursor.is_hidden = False
 
     def _display_buttons(self, card):
         """Display the buttons of a card.

--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -50,15 +50,9 @@ import json
 import board
 from digitalio import DigitalInOut
 import displayio
-try:
-    import adafruit_touchscreen
-except ImportError:
-    pass
-try:
-    from adafruit_cursorcontrol.cursorcontrol import Cursor
-    from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
-except ImportError:
-    pass
+import adafruit_touchscreen
+from adafruit_cursorcontrol.cursorcontrol import Cursor
+from adafruit_cursorcontrol.cursorcontrol_cursormanager import CursorManager
 import audioio
 from adafruit_display_text.label import Label
 from adafruit_button import Button


### PR DESCRIPTION
Adding conditional imports for touchscreen and cursorcontrol. CursorControl can not be imported by pyportal due to [gamepadshift](https://circuitpython.readthedocs.io/en/latest/shared-bindings/gamepadshift/GamePadShift.html) dependency.

Adding `cursor` property to init to match `touchscreen` property.