### PR TITLE
Update the pixel_shader usage of OnDiskBitmap

### DIFF
--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -406,7 +406,14 @@ class PYOA_Graphics:
             self._background_file = open(self._gamedirectory + "/" + filename, "rb")
             background = displayio.OnDiskBitmap(self._background_file)
             self._background_sprite = displayio.TileGrid(
-                background, pixel_shader=displayio.ColorConverter(), x=0, y=0
+                background,
+                pixel_shader=getattr(
+                    background, "pixel_shader", displayio.ColorConverter()
+                ),
+                # TODO: Once CP6 is no longer supported, replace the above line with below
+                # pixel_shader=background.pixel_shader,
+                x=0,
+                y=0,
             )
             self._background_group.append(self._background_sprite)
         if with_fade:


### PR DESCRIPTION
OnDiskBitmap has had incompatible changes in `7.0.0-alpha.3` - Ref: https://github.com/adafruit/circuitpython/pull/4823
This PR is part of a group of updates for this change - https://github.com/adafruit/circuitpython/issues/4982

This PR updates the library to the combined usage for CP6 & CP7 with a TODO to remove the CP6 compatibility in the future. It has been tested on a PyPortal with `6.3.0` and `7.0.0-alpha.4`