### PR TITLE
fix backgrounds and remove CP6 compatibility

### DIFF
--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -401,22 +401,12 @@ class PYOA_Graphics:
             self._background_group.pop()
 
         if filename:
-            if self._background_file:
-                self._background_file.close()
-            with open(
-                self._gamedirectory + "/" + filename, "rb"
-            ) as self._background_file:
-                # TODO: Once CP6 is no longer supported, pass combined filename into OnDiskBitmap
-                background = displayio.OnDiskBitmap(self._background_file)
-                self._background_sprite = displayio.TileGrid(
-                    background,
-                    pixel_shader=getattr(
-                        background, "pixel_shader", displayio.ColorConverter()
-                    ),
-                    # TODO: Once CP6 is no longer supported, replace the above line with below
-                    # pixel_shader=background.pixel_shader,
-                )
-                self._background_group.append(self._background_sprite)
+            background = displayio.OnDiskBitmap(self._gamedirectory + "/" + filename)
+            self._background_sprite = displayio.TileGrid(
+                background,
+                pixel_shader=background.pixel_shader,
+            )
+            self._background_group.append(self._background_sprite)
         if with_fade:
             self._display.refresh(target_frames_per_second=60)
             self.backlight_fade(1.0)


### PR DESCRIPTION
resolves #28 

There were a few options to resolve this:

1) remove `with` context and add a exception for pylint
2) remove the CP6 compatibility version now that 7 has a stable release. Starting with CP7 the filename can be passed directly to OnDiskBitmap which avoids the library needing to open or managed the open file at all. Instead we just pass the string filepath to OnDiskBitmap and it handles the file internally.

I went with option 2 since we do have a 7 stable release now and since doing it this way doesn't require the pylint exception.

Tested successfully on PyPortal:
```
Adafruit CircuitPython 7.1.0-beta.0 on 2021-11-12; Adafruit PyPortal with samd51j20
Board ID:pyportal
```