### PR TITLE
support optional text_background_color for cards

### DIFF
--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -227,12 +227,23 @@ class PYOA_Graphics:
         """
         text = card.get("text", None)
         text_color = card.get("text_color", 0x0)  # default to black
+        text_background_color = card.get("text_background_color", None)
         if text:
             try:
                 text_color = int(text_color)  # parse the JSON string to hex int
             except ValueError:
                 text_color = 0x0
-            self.set_text(text, text_color)
+
+            try:
+                text_background_color = int(
+                    text_background_color
+                )  # parse the JSON string to hex int
+            except ValueError:
+                text_background_color = None
+            except TypeError:
+                text_background_color = None
+
+            self.set_text(text, text_color, background_color=text_background_color)
 
     def _play_sound_for(self, card):
         """If there's a sound, start playing it.
@@ -356,7 +367,7 @@ class PYOA_Graphics:
         self._wavfile = None
         self._speaker_enable.value = False
 
-    def set_text(self, text, color):
+    def set_text(self, text, color, background_color=None):
         """Display the test for a card.
 
         :param Union(None,str) text: the text to display
@@ -385,6 +396,8 @@ class PYOA_Graphics:
             self._text.x = text_x
             self._text.y = text_y
             self._text.color = color
+            if background_color:
+                self._text.background_color = background_color
             self._text_group.append(self._text)
 
     def set_background(self, filename, *, with_fade=True):

--- a/examples/cyoa/cyoa.json
+++ b/examples/cyoa/cyoa.json
@@ -21,6 +21,7 @@
     "background_image": "page01.bmp",
     "text": "You do not have any friends so you decide that it might be a good idea to build a robot friend. You're unsure if you want to do this, so now is the time to decide. Do you want to build a robot friend?",
     "text_color": "0x000001",
+    "text_background_color": "0xeeeeee",
     "sound": "sound_01.wav",
     "button01_text": "Yes",
     "button01_goto_card_id": "continue?",


### PR DESCRIPTION
I noticed that one of the cards in the `cyoa/` example has a grid of grey pixels for it's background image with black text on top of it.

The grid makes the text pixelated and a little difficult to read. 


I've added a new `text_background_color` property that can be specified int he card configuration JSON to set a desired background color on the labeled, and modified that one page to use this new feature to put a more contrasting color behind the text.

Here is the slide with the current library (including the background img fix from #29):
![pyoa_text_bg_before](https://user-images.githubusercontent.com/2406189/145685640-22e88a46-0567-4d88-b8a7-6211b7563fec.png)

Here is the slide with the changes from this PR:
![pyoa_text_bg_after](https://user-images.githubusercontent.com/2406189/145685649-155a5f92-4ccd-4b5a-a925-bd44c1df5048.png)

