### PR TITLE
add bitmap_font to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Adafruit-Blinka
 adafruit-circuitpython-display-button
 adafruit-circuitpython-display-text
 adafruit-circuitpython-touchscreen
+adafruit-circuitpython-bitmap_font


### PR DESCRIPTION
I am not sure why there was a difference but #26 passed when created, but then failed when merged/released.

I think this will allow the sphinx build to complete successfully to get back to passing CI

