### PR TITLE
handle no .auto-brightness

### DIFF
--- a/adafruit_pyoa.py
+++ b/adafruit_pyoa.py
@@ -87,7 +87,10 @@ class PYOA_Graphics:
         self._background_file = None
         self._wavfile = None
 
-        self._display.auto_brightness = False
+        try:
+            self._display.auto_brightness = False
+        except AttributeError:
+            pass
         self.backlight_fade(0)
         self._display.show(self.root_group)
         self.touchscreen = None


### PR DESCRIPTION
CircuitPython 8 builds have dropped support for `Display.auto_brightness` (https://github.com/adafruit/circuitpython/pull/6734). These changes handle the attribute no longer being available in 8.x.x, while still working on 7.x.x.

See https://github.com/adafruit/Adafruit_Learning_System_Guides/pull/2239 for a more detailed explanation.